### PR TITLE
Feature/kyv 1272 invoicing required fields and other fixes

### DIFF
--- a/packages/payment-experience-api/src/api/invoicingRedirectController.spec.ts
+++ b/packages/payment-experience-api/src/api/invoicingRedirectController.spec.ts
@@ -72,6 +72,11 @@ const orderBackendResponseMock = {
 }
 
 describe('Test invoicing redirect controller', () => {
+  beforeEach(() => {
+    sendErrorNotificationMock.mockClear()
+    sendOrderConfirmationEmailToCustomerMock.mockClear()
+  })
+
   it('Test invoicing entry creation', async () => {
     process.env.REDIRECT_PAYMENT_URL_BASE = 'https://test.dev.hel'
     process.env.CONFIGURATION_BACKEND_URL = 'https://test.dev.hel'

--- a/packages/payment-experience-api/src/api/invoicingRedirectController.spec.ts
+++ b/packages/payment-experience-api/src/api/invoicingRedirectController.spec.ts
@@ -487,7 +487,8 @@ describe('Test invoicing redirect controller', () => {
     )
     expect(sendErrorNotificationMock).toHaveBeenCalledTimes(1)
     expect(sendErrorNotificationMock.mock.calls[0][0]).toEqual({
-      cause: 'ValidationError: this is invalid',
+      cause:
+        'ValidationError: Accounting information should only have internalOrder or profitCenter defined. If neither is given then project has to be defined.',
       header: 'Error - Creating invoicing entry for order failed',
       message:
         'Creating invoicing entry for order 145d8829-07b7-4b03-ab0e-24063958ab9b failed',
@@ -517,7 +518,8 @@ describe('Test invoicing redirect controller', () => {
     )
     expect(sendErrorNotificationMock).toHaveBeenCalledTimes(2)
     expect(sendErrorNotificationMock.mock.calls[1][0]).toEqual({
-      cause: 'ValidationError: this is invalid',
+      cause:
+        'ValidationError: Accounting information should only have internalOrder or profitCenter defined. If neither is given then project has to be defined.',
       header: 'Error - Creating invoicing entry for order failed',
       message:
         'Creating invoicing entry for order 145d8829-07b7-4b03-ab0e-24063958ab9b failed',

--- a/packages/payment-experience-api/src/api/invoicingRedirectController.spec.ts
+++ b/packages/payment-experience-api/src/api/invoicingRedirectController.spec.ts
@@ -1,0 +1,269 @@
+import axios from 'axios'
+import type { PaytrailStatus } from '@verkkokauppa/payment-backend'
+import type { Response } from 'express'
+import { InvoicingRedirectController } from './invoicingRedirectController'
+
+jest.mock('axios')
+const axiosMock = axios as jest.Mocked<typeof axios>
+
+const merchantId = 'merchantId'
+
+const orderBackendResponseMock = {
+  order: {
+    orderId: '145d8829-07b7-4b03-ab0e-24063958ab9b',
+    namespace: 'test',
+    user: 'test@test.dev.hel',
+    createdAt: '1619157868',
+    type: 'order',
+    incrementId: '1',
+    merchant: {
+      merchantName: 'merchantName',
+      merchantStreet: 'merchantStreet',
+      merchantZip: 'merchantZip',
+      merchantCity: 'merchantCity',
+      merchantEmail: 'merchantEmail',
+      merchantPhone: 'merchantPhone',
+      merchantUrl: 'merchantUrl',
+      merchantBusinessId: 'merchantBusinessId',
+    },
+    customer: {
+      firstName: 'Essi',
+      lastName: 'esimerkki',
+      email: 'essi.esimerkki@gmail.com',
+      phone: '+358123456789',
+      address: 'Esimerkkiosoite 1',
+      district: '123456 Esimerkkitoimipaikka',
+    },
+    invoice: {
+      businessId: 'businessId',
+      name: 'TMI Essi Esimerkki',
+      address: 'Esimerkkiosoite 1',
+      postcode: '123456',
+      city: 'Esimerkkitoimipaikka',
+    },
+  },
+  items: [
+    {
+      orderId: '145d8829-07b7-4b03-ab0e-24063958ab9b',
+      merchantId: merchantId,
+      orderItemId: '19699acf-b0a3-440f-818f-e582825fa3a7',
+      productId: 'dummy-product',
+      quantity: 1,
+      productName: 'Product Name',
+      unit: 'pcs',
+      rowPriceNet: '100',
+      rowPriceVat: '24',
+      rowPriceTotal: '124',
+      priceVat: '24',
+      priceNet: '100',
+      priceGross: '124',
+      vatPercentage: '24',
+      invoicingDate: '2024-04-12',
+    },
+  ],
+}
+
+describe('Test invoicing redirect controller', () => {
+  it('Test invoicing entry creation', async () => {
+    process.env.REDIRECT_PAYMENT_URL_BASE = 'https://test.dev.hel'
+    process.env.CONFIGURATION_BACKEND_URL = 'https://test.dev.hel'
+    process.env.MESSAGE_BACKEND_URL = 'https://test.dev.hel'
+    process.env.PAYMENT_BACKEND_URL = 'https://test.dev.hel/'
+    process.env.MERCHANT_API_URL = 'https://test.dev.hel'
+    process.env.ORDER_BACKEND_URL = 'https://test.dev.hel'
+    process.env.PRODUCT_BACKEND_URL = 'https://test.dev.hel'
+
+    const configMock = {
+      configurationId: '2f815a93-4c5c-442f-ba09-f294ecc12679',
+      namespace: 'test',
+      configurationKey: 'ORDER_CREATED_REDIRECT_URL',
+      configurationValue: 'https://service.dev.hel',
+      restricted: false,
+    }
+
+    const merchantConfigMock = {
+      configurationId: '431eec7a-3b67-4c0f-8f6f-93522def1d74',
+      namespace: 'test',
+      configurationKey: 'MERCHANT_NAME',
+      configurationValue: 'nimi',
+      restricted: false,
+    }
+
+    const merchantTermsOfServiceUrlConfigMock = {
+      configurationId: '431eec7a-3b67-4c0f-8f6f-93522def1d75',
+      namespace: 'test',
+      configurationKey: 'merchantTermsOfServiceUrl',
+      configurationValue: 'termsOfServiceUrl',
+      restricted: false,
+    }
+
+    const paymentMock = {
+      paymentId: 'dummy-payment',
+      namespace: 'asukaspysakointi',
+      orderId: 'dummy-order',
+      status: 'payment_created',
+      paymentMethod: 'nordea',
+      paymentType: 'order',
+      totalExclTax: 200,
+      total: 248,
+      taxAmount: 48,
+      description: null,
+      additionalInfo: '{"payment_method": nordea}',
+      token: '427a38b2607b105de58c7dbda2d8ce2f6fcb31d6cc52f77b8818c0b5dcd503f5',
+      paymentMethodLabel: 'paymentMethodLabel',
+    }
+
+    const mockPaytrailStatus = {
+      paymentPaid: true,
+      canRetry: true,
+      valid: true,
+      authorized: true,
+      paymentType: 'invoice',
+    } as PaytrailStatus
+
+    const mockAccountingEntryForOrder = {
+      orderId: 'orderId',
+      createdAt: 'createdAt',
+      items: [
+        {
+          orderId: '145d8829-07b7-4b03-ab0e-24063958ab9b',
+          orderItemId: '19699acf-b0a3-440f-818f-e582825fa3a7',
+          productId: 'dummy-product',
+        },
+      ],
+    }
+
+    const mockProductAccounting = [
+      {
+        productId: 'dummy-product',
+        vatCode: 'vatCode',
+        internalOrder: 'internalOrder',
+        profitCenter: 'profitCenter',
+        balanceProfitCenter: 'balanceProfitCenter',
+        project: 'project',
+        operationArea: 'operationArea',
+        companyCode: 'companyCode',
+        mainLedgerAccount: 'mainLedgerAccount',
+      },
+    ]
+
+    const mockProductInvoicing = [
+      {
+        productId: 'dummy-product',
+        salesOrg: 'salesOrg',
+        salesOffice: 'salesOffice',
+        material: 'material',
+        orderType: 'orderType',
+      },
+    ]
+
+    const mockProduct = { productId: 'dummy-product', name: 'Test' }
+
+    axiosMock.get.mockImplementation((url, data?: any) => {
+      if (url.includes(`/payment/invoice/check-return-url`)) {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(data.params).toEqual({
+          orderId: orderBackendResponseMock.order.orderId,
+          merchantId: merchantId,
+        })
+        return Promise.resolve({
+          data: mockPaytrailStatus,
+        })
+      }
+      if (url.includes(`/public/getAll`)) {
+        return Promise.resolve({
+          data: [
+            configMock,
+            merchantConfigMock,
+            merchantTermsOfServiceUrlConfigMock,
+          ],
+        })
+      }
+      if (url.includes(`/merchant/test`)) {
+        return Promise.resolve({
+          data: [
+            configMock,
+            merchantConfigMock,
+            merchantTermsOfServiceUrlConfigMock,
+          ],
+        })
+      }
+      if (url.includes(`/public/get`)) {
+        return Promise.resolve({ data: configMock })
+      }
+      if (url.includes(`/payment/online/get`)) {
+        return Promise.resolve({ data: paymentMock })
+      }
+      if (url.includes(`/order/get`)) {
+        return Promise.resolve({ data: orderBackendResponseMock })
+      }
+      if (url.includes(`/product/get`)) {
+        return Promise.resolve({ data: mockProduct })
+      }
+      if (url.includes(`/product/accounting/list`)) {
+        return Promise.resolve({ data: mockProductAccounting })
+      }
+      if (url.includes(`termsOfServiceUrl`)) {
+        return Promise.resolve({ data: 'binary' })
+      }
+
+      console.log(url)
+      console.log(data)
+      return Promise.resolve({})
+    })
+
+    axiosMock.post.mockImplementation((url, data?: any) => {
+      if (url.includes(`/order/invoicing/create`)) {
+        return Promise.resolve({ data: mockAccountingEntryForOrder })
+      }
+      if (url.includes(`/product/invoicing/list`)) {
+        return Promise.resolve({ data: mockProductInvoicing })
+      }
+      if (url.includes(`/order/setAccounted`)) {
+        return Promise.resolve({})
+      }
+      if (url.includes(`/message/send/email`)) {
+        return Promise.resolve({ data: 'email' })
+      }
+
+      console.log(url)
+      console.log(data)
+      return Promise.resolve({})
+    })
+
+    const invoicingRedirectController = new InvoicingRedirectController()
+
+    const mockRequest = {
+      query: {
+        orderId: orderBackendResponseMock.order.orderId,
+        user: orderBackendResponseMock.order.user,
+      },
+      httpVersion: 'HTTP/:1.1',
+    } as any
+    mockRequest.get = jest.fn()
+
+    const res = ({} as unknown) as Response
+    const mockGetFunction = jest.fn()
+
+    mockGetFunction.mockImplementation((key) => {
+      if (key.includes(`user`)) {
+        return 'dummy-user'
+      }
+      if (key.includes(`content-length`)) {
+        return 'content-length'
+      }
+      console.log(key)
+      return 'mockGetFunction.mockImplementation'
+    })
+    res.get = mockGetFunction
+    res.status = jest.fn().mockReturnValue(res)
+    res.json = jest.fn().mockReturnValue(res)
+    res.redirect = jest.fn()
+
+    await invoicingRedirectController.execute(mockRequest as any, res)
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      'https://service.dev.hel/success?orderId=145d8829-07b7-4b03-ab0e-24063958ab9b&user=test%40test.dev.hel'
+    )
+  })
+})

--- a/packages/payment-experience-api/src/api/invoicingRedirectController.spec.ts
+++ b/packages/payment-experience-api/src/api/invoicingRedirectController.spec.ts
@@ -3,6 +3,14 @@ import type { PaytrailStatus } from '@verkkokauppa/payment-backend'
 import type { Response } from 'express'
 import { InvoicingRedirectController } from './invoicingRedirectController'
 
+jest.mock('@verkkokauppa/message-backend')
+const sendErrorNotificationMock = require('@verkkokauppa/message-backend').sendErrorNotification.mockImplementation(
+  () => []
+)
+const sendOrderConfirmationEmailToCustomerMock = require('@verkkokauppa/message-backend').sendOrderConfirmationEmailToCustomer.mockImplementation(
+  () => []
+)
+
 jest.mock('axios')
 const axiosMock = axios as jest.Mocked<typeof axios>
 
@@ -137,7 +145,7 @@ describe('Test invoicing redirect controller', () => {
       {
         productId: 'dummy-product',
         vatCode: 'vatCode',
-        internalOrder: 'internalOrder',
+        internalOrder: '',
         profitCenter: 'profitCenter',
         balanceProfitCenter: 'balanceProfitCenter',
         project: 'project',
@@ -265,5 +273,274 @@ describe('Test invoicing redirect controller', () => {
       302,
       'https://service.dev.hel/success?orderId=145d8829-07b7-4b03-ab0e-24063958ab9b&user=test%40test.dev.hel'
     )
+    expect(sendErrorNotificationMock).toHaveBeenCalledTimes(0)
+    expect(sendOrderConfirmationEmailToCustomerMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('Test invoicing entry creation with faulty invoicing data', async () => {
+    process.env.REDIRECT_PAYMENT_URL_BASE = 'https://test.dev.hel'
+    process.env.CONFIGURATION_BACKEND_URL = 'https://test.dev.hel'
+    process.env.MESSAGE_BACKEND_URL = 'https://test.dev.hel'
+    process.env.PAYMENT_BACKEND_URL = 'https://test.dev.hel/'
+    process.env.MERCHANT_API_URL = 'https://test.dev.hel'
+    process.env.ORDER_BACKEND_URL = 'https://test.dev.hel'
+    process.env.PRODUCT_BACKEND_URL = 'https://test.dev.hel'
+
+    const configMock = {
+      configurationId: '2f815a93-4c5c-442f-ba09-f294ecc12679',
+      namespace: 'test',
+      configurationKey: 'ORDER_CREATED_REDIRECT_URL',
+      configurationValue: 'https://service.dev.hel',
+      restricted: false,
+    }
+
+    const merchantConfigMock = {
+      configurationId: '431eec7a-3b67-4c0f-8f6f-93522def1d74',
+      namespace: 'test',
+      configurationKey: 'MERCHANT_NAME',
+      configurationValue: 'nimi',
+      restricted: false,
+    }
+
+    const merchantTermsOfServiceUrlConfigMock = {
+      configurationId: '431eec7a-3b67-4c0f-8f6f-93522def1d75',
+      namespace: 'test',
+      configurationKey: 'merchantTermsOfServiceUrl',
+      configurationValue: 'termsOfServiceUrl',
+      restricted: false,
+    }
+
+    const paymentMock = {
+      paymentId: 'dummy-payment',
+      namespace: 'asukaspysakointi',
+      orderId: 'dummy-order',
+      status: 'payment_created',
+      paymentMethod: 'nordea',
+      paymentType: 'order',
+      totalExclTax: 200,
+      total: 248,
+      taxAmount: 48,
+      description: null,
+      additionalInfo: '{"payment_method": nordea}',
+      token: '427a38b2607b105de58c7dbda2d8ce2f6fcb31d6cc52f77b8818c0b5dcd503f5',
+      paymentMethodLabel: 'paymentMethodLabel',
+    }
+
+    const mockPaytrailStatus = {
+      paymentPaid: true,
+      canRetry: true,
+      valid: true,
+      authorized: true,
+      paymentType: 'invoice',
+    } as PaytrailStatus
+
+    const mockAccountingEntryForOrder = {
+      orderId: 'orderId',
+      createdAt: 'createdAt',
+      items: [
+        {
+          orderId: '145d8829-07b7-4b03-ab0e-24063958ab9b',
+          orderItemId: '19699acf-b0a3-440f-818f-e582825fa3a7',
+          productId: 'dummy-product',
+        },
+      ],
+    }
+
+    const mockProductInvoicing = [
+      {
+        productId: 'dummy-product',
+        salesOrg: 'salesOrg',
+        salesOffice: 'salesOffice',
+        material: 'material',
+        orderType: 'orderType',
+      },
+    ]
+
+    const mockProduct = { productId: 'dummy-product', name: 'Test' }
+
+    let mockFaultyProductAccounting: object[] = [
+      {
+        productId: 'dummy-product',
+        vatCode: 'vatCode',
+        internalOrder: null,
+        profitCenter: null,
+        balanceProfitCenter: 'balanceProfitCenter',
+        project: null,
+        operationArea: 'operationArea',
+        companyCode: 'companyCode',
+        mainLedgerAccount: 'mainLedgerAccount',
+      },
+    ]
+
+    axiosMock.get.mockImplementation((url, data?: any) => {
+      if (url.includes(`/payment/invoice/check-return-url`)) {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(data.params).toEqual({
+          orderId: orderBackendResponseMock.order.orderId,
+          merchantId: merchantId,
+        })
+        return Promise.resolve({
+          data: mockPaytrailStatus,
+        })
+      }
+      if (url.includes(`/public/getAll`)) {
+        return Promise.resolve({
+          data: [
+            configMock,
+            merchantConfigMock,
+            merchantTermsOfServiceUrlConfigMock,
+          ],
+        })
+      }
+      if (url.includes(`/merchant/test`)) {
+        return Promise.resolve({
+          data: [
+            configMock,
+            merchantConfigMock,
+            merchantTermsOfServiceUrlConfigMock,
+          ],
+        })
+      }
+      if (url.includes(`/public/get`)) {
+        return Promise.resolve({ data: configMock })
+      }
+      if (url.includes(`/payment/online/get`)) {
+        return Promise.resolve({ data: paymentMock })
+      }
+      if (url.includes(`/order/get`)) {
+        return Promise.resolve({ data: orderBackendResponseMock })
+      }
+      if (url.includes(`/product/get`)) {
+        return Promise.resolve({ data: mockProduct })
+      }
+      if (url.includes(`/product/accounting/list`)) {
+        return Promise.resolve({ data: mockFaultyProductAccounting })
+      }
+      if (url.includes(`termsOfServiceUrl`)) {
+        return Promise.resolve({ data: 'binary' })
+      }
+
+      console.log(url)
+      console.log(data)
+      return Promise.resolve({})
+    })
+
+    axiosMock.post.mockImplementation((url, data?: any) => {
+      if (url.includes(`/order/invoicing/create`)) {
+        return Promise.resolve({ data: mockAccountingEntryForOrder })
+      }
+      if (url.includes(`/product/invoicing/list`)) {
+        return Promise.resolve({ data: mockProductInvoicing })
+      }
+      if (url.includes(`/order/setAccounted`)) {
+        return Promise.resolve({})
+      }
+      if (url.includes(`/message/send/email`)) {
+        return Promise.resolve({ data: 'email' })
+      }
+
+      console.log(url)
+      console.log(data)
+      return Promise.resolve({})
+    })
+
+    const invoicingRedirectController = new InvoicingRedirectController()
+
+    const mockRequest = {
+      query: {
+        orderId: orderBackendResponseMock.order.orderId,
+        user: orderBackendResponseMock.order.user,
+      },
+      httpVersion: 'HTTP/:1.1',
+    } as any
+    mockRequest.get = jest.fn()
+
+    const res = ({} as unknown) as Response
+    const mockGetFunction = jest.fn()
+
+    mockGetFunction.mockImplementation((key) => {
+      if (key.includes(`user`)) {
+        return 'dummy-user'
+      }
+      if (key.includes(`content-length`)) {
+        return 'content-length'
+      }
+      console.log(key)
+      return 'mockGetFunction.mockImplementation'
+    })
+    res.get = mockGetFunction
+    res.status = jest.fn().mockReturnValue(res)
+    res.json = jest.fn().mockReturnValue(res)
+    res.redirect = jest.fn()
+
+    // test with internalOrder, profitCenter and project empty
+    // should send error email notification but pass
+    await invoicingRedirectController.execute(mockRequest as any, res)
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      'https://service.dev.hel/success?orderId=145d8829-07b7-4b03-ab0e-24063958ab9b&user=test%40test.dev.hel'
+    )
+    expect(sendErrorNotificationMock).toHaveBeenCalledTimes(1)
+    expect(sendErrorNotificationMock.mock.calls[0][0]).toEqual({
+      cause: 'ValidationError: this is invalid',
+      header: 'Error - Creating invoicing entry for order failed',
+      message:
+        'Creating invoicing entry for order 145d8829-07b7-4b03-ab0e-24063958ab9b failed',
+    })
+    expect(sendOrderConfirmationEmailToCustomerMock).toHaveBeenCalledTimes(1)
+
+    // test with internalOrder, profitCenter and project defined
+    // should send error email notification but pass
+    mockFaultyProductAccounting = [
+      {
+        productId: 'dummy-product',
+        vatCode: 'vatCode',
+        internalOrder: 'internalOrder',
+        profitCenter: 'profitCenter',
+        balanceProfitCenter: 'balanceProfitCenter',
+        project: 'project',
+        operationArea: 'operationArea',
+        companyCode: 'companyCode',
+        mainLedgerAccount: 'mainLedgerAccount',
+      },
+    ]
+
+    await invoicingRedirectController.execute(mockRequest as any, res)
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      'https://service.dev.hel/success?orderId=145d8829-07b7-4b03-ab0e-24063958ab9b&user=test%40test.dev.hel'
+    )
+    expect(sendErrorNotificationMock).toHaveBeenCalledTimes(2)
+    expect(sendErrorNotificationMock.mock.calls[1][0]).toEqual({
+      cause: 'ValidationError: this is invalid',
+      header: 'Error - Creating invoicing entry for order failed',
+      message:
+        'Creating invoicing entry for order 145d8829-07b7-4b03-ab0e-24063958ab9b failed',
+    })
+    expect(sendOrderConfirmationEmailToCustomerMock).toHaveBeenCalledTimes(2)
+
+    // finally proper data where only project is defined
+    // should not send error email notification and should pass
+    mockFaultyProductAccounting = [
+      {
+        productId: 'dummy-product',
+        vatCode: 'vatCode',
+        internalOrder: null,
+        profitCenter: null,
+        balanceProfitCenter: 'balanceProfitCenter',
+        project: 'project',
+        operationArea: 'operationArea',
+        companyCode: 'companyCode',
+        mainLedgerAccount: 'mainLedgerAccount',
+      },
+    ]
+
+    await invoicingRedirectController.execute(mockRequest as any, res)
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      'https://service.dev.hel/success?orderId=145d8829-07b7-4b03-ab0e-24063958ab9b&user=test%40test.dev.hel'
+    )
+    expect(sendErrorNotificationMock).toHaveBeenCalledTimes(2)
+    expect(sendOrderConfirmationEmailToCustomerMock).toHaveBeenCalledTimes(3)
   })
 })

--- a/packages/payment-experience-api/src/api/invoicingRedirectController.ts
+++ b/packages/payment-experience-api/src/api/invoicingRedirectController.ts
@@ -125,81 +125,90 @@ export class InvoicingRedirectController extends AbstractController {
         productIds: order.items.map((i) => i.productId),
       })
 
-      await createInvoicingEntryForOrder({
-        items: order.items.map((item) => {
-          const productAccounting = productAccountings.find(
-            (i) => i?.productId === item.productId
-          )
-          if (!productAccounting) {
-            throw new ExperienceError({
-              code: 'failed-to-find-product-accounting',
-              message: `No accounting entry found for product ${item.productId}`,
-              responseStatus: StatusCode.InternalServerError,
-              logLevel: 'error',
-            })
-          }
-          const productInvoicing = productInvoicings.find(
-            (i) => i?.productId === item.productId
-          )
-          if (!productInvoicing) {
-            throw new ExperienceError({
-              code: 'failed-to-find-product-invoicing',
-              message: `No invoicing entry found for product ${item.productId}`,
-              responseStatus: StatusCode.InternalServerError,
-              logLevel: 'error',
-            })
-          }
-          return yup
-            .object({
-              orderId: yup.string().required(),
-              orderIncrementId: yup.string().required(),
-              orderItemId: yup.string().required(),
-              invoicingDate: yup.string().required(),
-              customerOvt: yup.string().nullable().default(''),
-              customerYid: yup.string().required(),
-              customerName: yup.string().required(),
-              customerAddress: yup.string().required(),
-              customerPostcode: yup.string().required(),
-              customerCity: yup.string().required(),
-              material: yup.string().required(),
-              orderType: yup.string().required(),
-              salesOrg: yup.string().required(),
-              salesOffice: yup.string().required(),
-              materialDescription: yup.string().required(),
-              quantity: yup.number().required(),
-              unit: yup.string().required(),
-              priceNet: yup.string().required(),
-              internalOrder: yup.string().notRequired(),
-              profitCenter: yup.string().notRequired(),
-              project: yup.string().notRequired(),
-              operationArea: yup.string().notRequired(),
-            })
-            .validateSync({
-              orderId: order.orderId,
-              orderIncrementId: order.incrementId,
-              orderItemId: item.orderItemId,
-              invoicingDate: item.invoicingDate?.toISOString(),
-              customerYid: order.invoice?.businessId,
-              customerOvt: order.invoice?.ovtId,
-              customerName: order.invoice?.name,
-              customerAddress: order.invoice?.address,
-              customerPostcode: order.invoice?.postcode,
-              customerCity: order.invoice?.city,
-              material: productInvoicing.material,
-              orderType: productInvoicing.orderType,
-              salesOrg: productInvoicing.salesOrg,
-              salesOffice: productInvoicing.salesOffice,
-              materialDescription: item.productName,
-              quantity: item.quantity,
-              unit: item.unit,
-              priceNet: item.priceNet,
-              internalOrder: productAccounting.internalOrder,
-              profitCenter: productAccounting.profitCenter,
-              project: productAccounting.project,
-              operationArea: productAccounting.operationArea,
-            })
-        }),
-      })
+      try {
+        await createInvoicingEntryForOrder({
+          items: order.items.map((item) => {
+            const productAccounting = productAccountings.find(
+              (i) => i?.productId === item.productId
+            )
+            if (!productAccounting) {
+              throw new ExperienceError({
+                code: 'failed-to-find-product-accounting',
+                message: `No accounting entry found for product ${item.productId}`,
+                responseStatus: StatusCode.InternalServerError,
+                logLevel: 'error',
+              })
+            }
+            const productInvoicing = productInvoicings.find(
+              (i) => i?.productId === item.productId
+            )
+            if (!productInvoicing) {
+              throw new ExperienceError({
+                code: 'failed-to-find-product-invoicing',
+                message: `No invoicing entry found for product ${item.productId}`,
+                responseStatus: StatusCode.InternalServerError,
+                logLevel: 'error',
+              })
+            }
+            return yup
+              .object({
+                orderId: yup.string().required(),
+                orderIncrementId: yup.string().required(),
+                orderItemId: yup.string().required(),
+                invoicingDate: yup.string().required(),
+                customerOvt: yup.string().nullable().default(''),
+                customerYid: yup.string().required(),
+                customerName: yup.string().required(),
+                customerAddress: yup.string().required(),
+                customerPostcode: yup.string().required(),
+                customerCity: yup.string().required(),
+                material: yup.string().required(),
+                orderType: yup.string().required(),
+                salesOrg: yup.string().required(),
+                salesOffice: yup.string().required(),
+                materialDescription: yup.string().required(),
+                quantity: yup.number().required(),
+                unit: yup.string().required(),
+                priceNet: yup.string().required(),
+                internalOrder: yup.string().notRequired(),
+                profitCenter: yup.string().notRequired(),
+                project: yup.string().nullable().default(''),
+                operationArea: yup.string().nullable().default(''),
+              })
+              .validateSync({
+                orderId: order.orderId,
+                orderIncrementId: order.incrementId,
+                orderItemId: item.orderItemId,
+                invoicingDate: item.invoicingDate?.toISOString(),
+                customerYid: order.invoice?.businessId,
+                customerOvt: order.invoice?.ovtId,
+                customerName: order.invoice?.name,
+                customerAddress: order.invoice?.address,
+                customerPostcode: order.invoice?.postcode,
+                customerCity: order.invoice?.city,
+                material: productInvoicing.material,
+                orderType: productInvoicing.orderType,
+                salesOrg: productInvoicing.salesOrg,
+                salesOffice: productInvoicing.salesOffice,
+                materialDescription: item.productName,
+                quantity: item.quantity,
+                unit: item.unit,
+                priceNet: item.priceNet,
+                internalOrder: productAccounting.internalOrder,
+                profitCenter: productAccounting.profitCenter,
+                project: productAccounting.project,
+                operationArea: productAccounting.operationArea,
+              })
+          }),
+        })
+      } catch (e) {
+        // send notification to Slack channel (email) that sending receipt faile
+        await sendErrorNotification({
+          message: `Creating invoicing entry for order ${orderId} failed`,
+          cause: e.toString(),
+          header: 'Error - Creating invoicing entry for order failed',
+        })
+      }
 
       try {
         await setOrderAsAccounted(orderId)
@@ -234,8 +243,8 @@ export class InvoicingRedirectController extends AbstractController {
         if (!(e instanceof OrderNotFoundError)) {
           await sendErrorNotification({
             cause: 'Invoicing redirect controller error',
-            message: `Failed to create invoicing (order ${orderId}, user ${user}, error ${e.toString()})`,
-            header: 'Error - Creating order invoicing failed',
+            message: `Error while handling invoicing (order ${orderId}, user ${user}, error ${e.toString()})`,
+            header: 'Error occurred in invoicing redirect controller',
           })
         }
       } catch (e) {
@@ -244,7 +253,7 @@ export class InvoicingRedirectController extends AbstractController {
 
       return res.redirect(
         302,
-        InvoicingRedirectController.fault(redirectUrl, user)
+        InvoicingRedirectController.success(redirectUrl, user)
       )
     }
   }

--- a/packages/payment-experience-api/src/api/invoicingRedirectController.ts
+++ b/packages/payment-experience-api/src/api/invoicingRedirectController.ts
@@ -175,27 +175,31 @@ export class InvoicingRedirectController extends AbstractController {
                 project: yup.string().nullable().default(''),
                 operationArea: yup.string().nullable().default(''),
               })
-              .test((value) => {
-                if (!value) return false
+              .test(
+                'Only one accounting identifier',
+                'Accounting information should only have internalOrder or profitCenter defined. If neither is given then project has to be defined.',
+                (value) => {
+                  if (!value) return false
 
-                // only internalOrder or profitCenter should be used
-                // if neither of them is used then project should be defined
-                const hasInternalOrder = !!value.internalOrder
-                const hasProfitCenter = !!value.profitCenter
-                const hasProject = !!value.project
+                  // only internalOrder or profitCenter should be used
+                  // if neither of them is used then project should be defined
+                  const hasInternalOrder = !!value.internalOrder
+                  const hasProfitCenter = !!value.profitCenter
+                  const hasProject = !!value.project
 
-                // InternalOrder and ProfitCenter should not be provided at the same time
-                if (hasInternalOrder && hasProfitCenter) {
-                  return false
+                  // InternalOrder and ProfitCenter should not be provided at the same time
+                  if (hasInternalOrder && hasProfitCenter) {
+                    return false
+                  }
+
+                  // if neither provided then project is required
+                  if (!hasInternalOrder && !hasProfitCenter) {
+                    return hasProject
+                  }
+
+                  return true
                 }
-
-                // if neither provided then project is required
-                if (!hasInternalOrder && !hasProfitCenter) {
-                  return hasProject
-                }
-
-                return true
-              })
+              )
               .validateSync({
                 orderId: order.orderId,
                 orderIncrementId: order.incrementId,

--- a/packages/payment-experience-api/src/api/invoicingRedirectController.ts
+++ b/packages/payment-experience-api/src/api/invoicingRedirectController.ts
@@ -170,10 +170,31 @@ export class InvoicingRedirectController extends AbstractController {
                 quantity: yup.number().required(),
                 unit: yup.string().required(),
                 priceNet: yup.string().required(),
-                internalOrder: yup.string().notRequired(),
-                profitCenter: yup.string().notRequired(),
+                internalOrder: yup.string().nullable().default(''),
+                profitCenter: yup.string().nullable().default(''),
                 project: yup.string().nullable().default(''),
                 operationArea: yup.string().nullable().default(''),
+              })
+              .test((value) => {
+                if (!value) return false
+
+                // only internalOrder or profitCenter should be used
+                // if neither of them is used then project should be defined
+                const hasInternalOrder = !!value.internalOrder
+                const hasProfitCenter = !!value.profitCenter
+                const hasProject = !!value.project
+
+                // InternalOrder and ProfitCenter should not be provided at the same time
+                if (hasInternalOrder && hasProfitCenter) {
+                  return false
+                }
+
+                // if neither provided then project is required
+                if (!hasInternalOrder && !hasProfitCenter) {
+                  return hasProject
+                }
+
+                return true
               })
               .validateSync({
                 orderId: order.orderId,
@@ -194,9 +215,9 @@ export class InvoicingRedirectController extends AbstractController {
                 quantity: item.quantity,
                 unit: item.unit,
                 priceNet: item.priceNet,
-                internalOrder: productAccounting.internalOrder,
-                profitCenter: productAccounting.profitCenter,
-                project: productAccounting.project,
+                internalOrder: productAccounting?.internalOrder,
+                profitCenter: productAccounting?.profitCenter,
+                project: productAccounting?.project,
                 operationArea: productAccounting.operationArea,
               })
           }),

--- a/packages/payment-experience-api/src/api/paytrailOnlinePaymentReturnController.ts
+++ b/packages/payment-experience-api/src/api/paytrailOnlinePaymentReturnController.ts
@@ -83,7 +83,7 @@ export class PaytrailOnlinePaymentReturnController extends AbstractController {
       const merchantId = parseMerchantIdFromFirstOrderItem(order)
 
       if (!merchantId) {
-        logger.error('Paytrail: No merchantId found from order')
+        logger.error(`Paytrail: No merchantId found from order ${orderId}`)
         return result.redirect(302, failureRedirectUrl.toString())
       }
 

--- a/packages/payment-experience-api/src/api/paytrailOnlineRefundPaymentCancelController.spec.ts
+++ b/packages/payment-experience-api/src/api/paytrailOnlineRefundPaymentCancelController.spec.ts
@@ -101,6 +101,7 @@ describe('Test paytrail refund payment cancel controller', () => {
           refundPaymentStatus: { valid: true },
         }),
         cause: 'Paytrail refund payment cancel controller called',
+        header: 'Error - Refund cancel controller called',
       })
     } else {
       expect(sendErrorNotificationMock).toHaveBeenCalledTimes(0)

--- a/packages/product-backend/src/service.ts
+++ b/packages/product-backend/src/service.ts
@@ -131,3 +131,26 @@ export const getProductAccountingBatch = async (p: {
     throw new GetProductAccountingFailure(productIds.join(','), e)
   }
 }
+
+export const validateAccountingValues = (p: { accounting }): boolean => {
+  const { accounting } = p
+  if (!accounting) return false
+
+  // only internalOrder or profitCenter should be used
+  // if neither of them is used then project should be defined
+  const hasInternalOrder = !!accounting.internalOrder
+  const hasProfitCenter = !!accounting.profitCenter
+  const hasProject = !!accounting.project
+
+  // InternalOrder and ProfitCenter should not be provided at the same time
+  if (hasInternalOrder && hasProfitCenter) {
+    return false
+  }
+
+  // if neither provided then project is required
+  if (!hasInternalOrder && !hasProfitCenter) {
+    return hasProject
+  }
+
+  return true
+}

--- a/packages/product-backend/src/service.ts
+++ b/packages/product-backend/src/service.ts
@@ -8,7 +8,7 @@ import {
   GetProductAccountingFailure,
   ProductAccountingNotFoundError,
 } from './errors'
-import { ExperienceFailure } from '@verkkokauppa/core'
+import { ExperienceFailure, logger } from '@verkkokauppa/core'
 
 type ProductBackendResponse = {
   id: string
@@ -132,7 +132,7 @@ export const getProductAccountingBatch = async (p: {
   }
 }
 
-export const validateAccountingValues = (p: { accounting }): boolean => {
+export const validateAccountingValues = (p: { accounting: any }): boolean => {
   const { accounting } = p
   if (!accounting) return false
 
@@ -141,7 +141,6 @@ export const validateAccountingValues = (p: { accounting }): boolean => {
   const hasInternalOrder = !!accounting.internalOrder
   const hasProfitCenter = !!accounting.profitCenter
   const hasProject = !!accounting.project
-
   // InternalOrder and ProfitCenter should not be provided at the same time
   if (hasInternalOrder && hasProfitCenter) {
     return false
@@ -150,6 +149,24 @@ export const validateAccountingValues = (p: { accounting }): boolean => {
   // if neither provided then project is required
   if (!hasInternalOrder && !hasProfitCenter) {
     return hasProject
+  }
+
+  return true
+}
+
+export const validateAccountingValuesForNextEntity = (p: {
+  accounting: any
+}): boolean => {
+  const { accounting } = p
+  if (!accounting) return true
+
+  // only internalOrder or profitCenter should be used
+  // if neither of them is used then project should be defined
+  const hasInternalOrder = !!accounting.internalOrder
+  const hasProfitCenter = !!accounting.profitCenter
+  // InternalOrder and ProfitCenter should not be provided at the same time
+  if (hasInternalOrder && hasProfitCenter) {
+    return false
   }
 
   return true

--- a/packages/product-experience-api/src/api/createProductAccountingController.ts
+++ b/packages/product-experience-api/src/api/createProductAccountingController.ts
@@ -23,6 +23,31 @@ const nextEntitySchema = yup
     project: yup.string().nullable().notRequired(),
     operationArea: yup.string().nullable().notRequired(),
   })
+  .test(
+    'Only one accounting identifier',
+    'Accounting information should only have internalOrder or profitCenter defined. If neither is given then project has to be defined.',
+    (value) => {
+      if (!value) return false
+
+      // only internalOrder or profitCenter should be used
+      // if neither of them is used then project should be defined
+      const hasInternalOrder = !!value.internalOrder
+      const hasProfitCenter = !!value.profitCenter
+      const hasProject = !!value.project
+
+      // InternalOrder and ProfitCenter should not be provided at the same time
+      if (hasInternalOrder && hasProfitCenter) {
+        return false
+      }
+
+      // if neither provided then project is required
+      if (!hasInternalOrder && !hasProfitCenter) {
+        return hasProject
+      }
+
+      return true
+    }
+  )
   .nullable()
   .notRequired()
 
@@ -30,33 +55,59 @@ const requestSchema = yup.object().shape({
   params: yup.object().shape({
     productId: yup.string().required(),
   }),
-  body: yup.object({
-    vatCode: yup.string().required(),
-    companyCode: yup.string().required(),
-    mainLedgerAccount: yup.string().required(),
-    internalOrder: yup.string().notRequired(),
-    profitCenter: yup.string().notRequired(),
-    balanceProfitCenter: yup.string().required(),
-    project: yup.string().notRequired(),
-    operationArea: yup.string().notRequired(),
-    productInvoicing: yup
-      .object({
-        salesOrg: yup.string().required().length(4),
-        salesOffice: yup.string().required().length(4),
-        material: yup.string().required().length(8),
-        orderType: yup.string().required().length(4),
-      })
-      .notRequired()
-      .default(undefined),
-    activeFrom: yup.date().nullable().notRequired(),
-    nextEntity: nextEntitySchema.when('activeFrom', {
-      is: (value: null | undefined) => value !== null && value !== undefined,
-      then: yup
-        .object()
-        .required('nextEntity is required when activeFrom is provided'),
-      otherwise: nextEntitySchema,
-    }),
-  }),
+  body: yup
+    .object({
+      vatCode: yup.string().required(),
+      companyCode: yup.string().required(),
+      mainLedgerAccount: yup.string().required(),
+      internalOrder: yup.string().notRequired(),
+      profitCenter: yup.string().notRequired(),
+      balanceProfitCenter: yup.string().required(),
+      project: yup.string().notRequired(),
+      operationArea: yup.string().notRequired(),
+      productInvoicing: yup
+        .object({
+          salesOrg: yup.string().required().length(4),
+          salesOffice: yup.string().required().length(4),
+          material: yup.string().required().length(8),
+          orderType: yup.string().required().length(4),
+        })
+        .notRequired()
+        .default(undefined),
+      activeFrom: yup.date().nullable().notRequired(),
+      nextEntity: nextEntitySchema.when('activeFrom', {
+        is: (value: null | undefined) => value !== null && value !== undefined,
+        then: yup
+          .object()
+          .required('nextEntity is required when activeFrom is provided'),
+        otherwise: nextEntitySchema,
+      }),
+    })
+    .test(
+      'Only one accounting identifier',
+      'Accounting information should only have internalOrder or profitCenter defined. If neither is given then project has to be defined.',
+      (value) => {
+        if (!value) return false
+
+        // only internalOrder or profitCenter should be used
+        // if neither of them is used then project should be defined
+        const hasInternalOrder = !!value.internalOrder
+        const hasProfitCenter = !!value.profitCenter
+        const hasProject = !!value.project
+
+        // InternalOrder and ProfitCenter should not be provided at the same time
+        if (hasInternalOrder && hasProfitCenter) {
+          return false
+        }
+
+        // if neither provided then project is required
+        if (!hasInternalOrder && !hasProfitCenter) {
+          return hasProject
+        }
+
+        return true
+      }
+    ),
   headers: yup.object().shape({
     'api-key': yup.string().required(),
     namespace: yup.string().required(),

--- a/packages/product-experience-api/src/api/createProductAccountingController.ts
+++ b/packages/product-experience-api/src/api/createProductAccountingController.ts
@@ -9,6 +9,7 @@ import {
   createProductAccounting,
   createProductInvoicing,
   validateAccountingValues,
+  validateAccountingValuesForNextEntity,
 } from '@verkkokauppa/product-backend'
 import * as yup from 'yup'
 import { validateApiKey } from '@verkkokauppa/configuration-backend'
@@ -26,28 +27,8 @@ const nextEntitySchema = yup
   })
   .test(
     'Only one accounting identifier',
-    'Accounting information should only have internalOrder or profitCenter defined. If neither is given then project has to be defined.',
-    (value) => {
-      if (!value) return false
-
-      // only internalOrder or profitCenter should be used
-      // if neither of them is used then project should be defined
-      const hasInternalOrder = !!value.internalOrder
-      const hasProfitCenter = !!value.profitCenter
-      const hasProject = !!value.project
-
-      // InternalOrder and ProfitCenter should not be provided at the same time
-      if (hasInternalOrder && hasProfitCenter) {
-        return false
-      }
-
-      // if neither provided then project is required
-      if (!hasInternalOrder && !hasProfitCenter) {
-        return hasProject
-      }
-
-      return true
-    }
+    'Accounting information should only have internalOrder or profitCenter defined.',
+    (value) => validateAccountingValuesForNextEntity({ accounting: value })
   )
   .nullable()
   .notRequired()
@@ -87,7 +68,7 @@ const requestSchema = yup.object().shape({
     .test(
       'Only one accounting identifier',
       'Accounting information should only have internalOrder or profitCenter defined. If neither is given then project has to be defined.',
-      (value) => validateAccountingValues(value)
+      (value) => validateAccountingValues({ accounting: value })
     ),
   headers: yup.object().shape({
     'api-key': yup.string().required(),

--- a/packages/product-experience-api/src/api/createProductAccountingController.ts
+++ b/packages/product-experience-api/src/api/createProductAccountingController.ts
@@ -8,6 +8,7 @@ import type { Response } from 'express'
 import {
   createProductAccounting,
   createProductInvoicing,
+  validateAccountingValues,
 } from '@verkkokauppa/product-backend'
 import * as yup from 'yup'
 import { validateApiKey } from '@verkkokauppa/configuration-backend'
@@ -86,27 +87,7 @@ const requestSchema = yup.object().shape({
     .test(
       'Only one accounting identifier',
       'Accounting information should only have internalOrder or profitCenter defined. If neither is given then project has to be defined.',
-      (value) => {
-        if (!value) return false
-
-        // only internalOrder or profitCenter should be used
-        // if neither of them is used then project should be defined
-        const hasInternalOrder = !!value.internalOrder
-        const hasProfitCenter = !!value.profitCenter
-        const hasProject = !!value.project
-
-        // InternalOrder and ProfitCenter should not be provided at the same time
-        if (hasInternalOrder && hasProfitCenter) {
-          return false
-        }
-
-        // if neither provided then project is required
-        if (!hasInternalOrder && !hasProfitCenter) {
-          return hasProject
-        }
-
-        return true
-      }
+      (value) => validateAccountingValues(value)
     ),
   headers: yup.object().shape({
     'api-key': yup.string().required(),


### PR DESCRIPTION
Added validation to internalOrder/profitCenter/project 
Added tests for invoicingRedirectController
Invoicing return controller no longer fails if invoice creation fails, just sends email notification. 
Invoicing return controller never directs to /failure anymore, just sends email notification.
fixed some test that were broken earlier