### PR TITLE
Feature/kyv 1279 invoice fixes

### DIFF
--- a/packages/payment-experience-api/src/api/invoicingRedirectController.spec.ts
+++ b/packages/payment-experience-api/src/api/invoicingRedirectController.spec.ts
@@ -550,4 +550,209 @@ describe('Test invoicing redirect controller', () => {
     expect(sendErrorNotificationMock).toHaveBeenCalledTimes(2)
     expect(sendOrderConfirmationEmailToCustomerMock).toHaveBeenCalledTimes(3)
   })
+
+  it('Test redirect to talpa success page', async () => {
+    process.env.REDIRECT_PAYMENT_URL_BASE = 'https://test.dev.hel'
+    process.env.CONFIGURATION_BACKEND_URL = 'https://test.dev.hel'
+    process.env.MESSAGE_BACKEND_URL = 'https://test.dev.hel'
+    process.env.PAYMENT_BACKEND_URL = 'https://test.dev.hel/'
+    process.env.MERCHANT_API_URL = 'https://test.dev.hel'
+    process.env.ORDER_BACKEND_URL = 'https://test.dev.hel'
+    process.env.PRODUCT_BACKEND_URL = 'https://test.dev.hel'
+
+    const configMock = {
+      configurationId: '2f815a93-4c5c-442f-ba09-f294ecc12679',
+      namespace: 'test',
+      configurationKey: 'ORDER_CREATED_REDIRECT_URL',
+      configurationValue: 'https://service.dev.hel',
+      restricted: false,
+    }
+
+    const merchantConfigMock = {
+      configurationId: '431eec7a-3b67-4c0f-8f6f-93522def1d74',
+      namespace: 'test',
+      configurationKey: 'MERCHANT_NAME',
+      configurationValue: 'nimi',
+      restricted: false,
+    }
+
+    const merchantTermsOfServiceUrlConfigMock = {
+      configurationId: '431eec7a-3b67-4c0f-8f6f-93522def1d75',
+      namespace: 'test',
+      configurationKey: 'merchantTermsOfServiceUrl',
+      configurationValue: 'termsOfServiceUrl',
+      restricted: false,
+    }
+
+    const paymentMock = {
+      paymentId: 'dummy-payment',
+      namespace: 'asukaspysakointi',
+      orderId: 'dummy-order',
+      status: 'payment_created',
+      paymentMethod: 'nordea',
+      paymentType: 'order',
+      totalExclTax: 200,
+      total: 248,
+      taxAmount: 48,
+      description: null,
+      additionalInfo: '{"payment_method": nordea}',
+      token: '427a38b2607b105de58c7dbda2d8ce2f6fcb31d6cc52f77b8818c0b5dcd503f5',
+      paymentMethodLabel: 'paymentMethodLabel',
+    }
+
+    const mockPaytrailStatus = {
+      paymentPaid: true,
+      canRetry: true,
+      valid: true,
+      authorized: true,
+      paymentType: 'invoice',
+    } as PaytrailStatus
+
+    const mockAccountingEntryForOrder = {
+      orderId: 'orderId',
+      createdAt: 'createdAt',
+      items: [
+        {
+          orderId: '145d8829-07b7-4b03-ab0e-24063958ab9b',
+          orderItemId: '19699acf-b0a3-440f-818f-e582825fa3a7',
+          productId: 'dummy-product',
+        },
+      ],
+    }
+
+    const mockProductAccounting = [
+      {
+        productId: 'dummy-product',
+        vatCode: 'vatCode',
+        internalOrder: '',
+        profitCenter: 'profitCenter',
+        balanceProfitCenter: 'balanceProfitCenter',
+        project: 'project',
+        operationArea: 'operationArea',
+        companyCode: 'companyCode',
+        mainLedgerAccount: 'mainLedgerAccount',
+      },
+    ]
+
+    const mockProductInvoicing = [
+      {
+        productId: 'dummy-product',
+        salesOrg: 'salesOrg',
+        salesOffice: 'salesOffice',
+        material: 'material',
+        orderType: 'orderType',
+      },
+    ]
+
+    const mockProduct = { productId: 'dummy-product', name: 'Test' }
+
+    axiosMock.get.mockImplementation((url, data?: any) => {
+      if (url.includes(`/payment/invoice/check-return-url`)) {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(data.params).toEqual({
+          orderId: orderBackendResponseMock.order.orderId,
+          merchantId: merchantId,
+        })
+        return Promise.resolve({
+          data: mockPaytrailStatus,
+        })
+      }
+      if (url.includes(`/public/getAll`)) {
+        return Promise.resolve({
+          data: [
+            configMock,
+            merchantConfigMock,
+            merchantTermsOfServiceUrlConfigMock,
+          ],
+        })
+      }
+      if (url.includes(`/merchant/test`)) {
+        return Promise.resolve({
+          data: [
+            configMock,
+            merchantConfigMock,
+            merchantTermsOfServiceUrlConfigMock,
+          ],
+        })
+      }
+      if (url.includes(`/public/get`)) {
+        return Promise.resolve({})
+      }
+      if (url.includes(`/payment/online/get`)) {
+        return Promise.resolve({ data: paymentMock })
+      }
+      if (url.includes(`/order/get`)) {
+        return Promise.resolve({ data: orderBackendResponseMock })
+      }
+      if (url.includes(`/product/get`)) {
+        return Promise.resolve({ data: mockProduct })
+      }
+      if (url.includes(`/product/accounting/list`)) {
+        return Promise.resolve({ data: mockProductAccounting })
+      }
+      if (url.includes(`termsOfServiceUrl`)) {
+        return Promise.resolve({ data: 'binary' })
+      }
+
+      console.log(url)
+      console.log(data)
+      return Promise.resolve({})
+    })
+
+    axiosMock.post.mockImplementation((url, data?: any) => {
+      if (url.includes(`/order/invoicing/create`)) {
+        return Promise.resolve({ data: mockAccountingEntryForOrder })
+      }
+      if (url.includes(`/product/invoicing/list`)) {
+        return Promise.resolve({ data: mockProductInvoicing })
+      }
+      if (url.includes(`/order/setAccounted`)) {
+        return Promise.resolve({})
+      }
+      if (url.includes(`/message/send/email`)) {
+        return Promise.resolve({ data: 'email' })
+      }
+
+      console.log(url)
+      console.log(data)
+      return Promise.resolve({})
+    })
+
+    const invoicingRedirectController = new InvoicingRedirectController()
+
+    const mockRequest = {
+      query: {
+        orderId: orderBackendResponseMock.order.orderId,
+        user: orderBackendResponseMock.order.user,
+      },
+      httpVersion: 'HTTP/:1.1',
+    } as any
+    mockRequest.get = jest.fn()
+
+    const res = ({} as unknown) as Response
+    const mockGetFunction = jest.fn()
+
+    mockGetFunction.mockImplementation((key) => {
+      if (key.includes(`user`)) {
+        return 'dummy-user'
+      }
+      if (key.includes(`content-length`)) {
+        return 'content-length'
+      }
+      console.log(key)
+      return 'mockGetFunction.mockImplementation'
+    })
+    res.get = mockGetFunction
+    res.status = jest.fn().mockReturnValue(res)
+    res.json = jest.fn().mockReturnValue(res)
+    res.redirect = jest.fn()
+
+    await invoicingRedirectController.execute(mockRequest as any, res)
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      'https://test.dev.hel/145d8829-07b7-4b03-ab0e-24063958ab9b/success?user=test%40test.dev.hel'
+    )
+    expect(sendErrorNotificationMock).toHaveBeenCalledTimes(0)
+    expect(sendOrderConfirmationEmailToCustomerMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/payment-experience-api/src/api/invoicingRedirectController.ts
+++ b/packages/payment-experience-api/src/api/invoicingRedirectController.ts
@@ -32,7 +32,12 @@ export class InvoicingRedirectController extends AbstractController {
   protected readonly requestSchema = null
 
   private static fault = (url: URL, user?: string | null) => {
-    url.pathname = 'failure'
+    if (!url.pathname.includes('success')) {
+      url.pathname = url.pathname.replace('success', 'failure')
+    } else {
+      url.pathname += 'failure'
+    }
+
     if (user) {
       url.searchParams.append('user', user)
     }
@@ -40,7 +45,9 @@ export class InvoicingRedirectController extends AbstractController {
   }
 
   private static success = (url: URL, user?: string) => {
-    url.pathname = 'success'
+    if (!url.pathname.includes('success')) {
+      url.pathname += 'success'
+    }
     if (user) {
       url.searchParams.append('user', user)
     }


### PR DESCRIPTION
Fixed redirect to add success to path if it does not exist in gotten redirect url. 
This works with redirect to customer and internal talpa success urls
